### PR TITLE
Enable alias imports from packages

### DIFF
--- a/apps/web/pages/index.tsx
+++ b/apps/web/pages/index.tsx
@@ -1,10 +1,15 @@
 import Link from 'next/link';
 import { SignedIn, SignedOut, UserButton } from '@clerk/nextjs';
+import { greet } from '@/utils';
+import type { ExampleType } from '@/types';
 
 export default function Home() {
+  const example: ExampleType = { id: '1', name: greet('World') };
+
   return (
     <main>
       <h1>AI SaaS Template</h1>
+      <p>{example.name}</p>
       <SignedIn>
         <UserButton afterSignOutUrl="/" />
         <p>

--- a/packages/types/index.ts
+++ b/packages/types/index.ts
@@ -1,0 +1,4 @@
+export interface ExampleType {
+  id: string;
+  name: string;
+}

--- a/packages/utils/index.ts
+++ b/packages/utils/index.ts
@@ -1,0 +1,3 @@
+export function greet(name: string): string {
+  return `Hello, ${name}!`;
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -13,7 +13,10 @@
     "isolatedModules": true,
     "noEmit": true,
     "baseUrl": ".",
-    "jsx": "preserve"
+    "jsx": "preserve",
+    "paths": {
+      "@/*": ["packages/*"]
+    }
   },
   "include": ["**/*.ts", "**/*.tsx"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
## Summary
- add basic `types` and `utils` packages
- map `@/*` paths to `packages/*`
- demonstrate alias imports in the web index page

## Testing
- `pnpm --filter web exec tsc --noEmit` *(fails: Cannot find module '@supabase/supabase-js' or its type declarations)*