### PR TITLE
Implement role based pages and prisma mappings

### DIFF
--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -1,0 +1,35 @@
+from fastapi import FastAPI, HTTPException
+from prisma import Prisma
+from pydantic import BaseModel
+
+app = FastAPI()
+prisma = Prisma()
+
+class TenantIn(BaseModel):
+    name: str
+
+class Tenant(TenantIn):
+    id: str
+
+@app.on_event("startup")
+async def startup():
+    await prisma.connect()
+
+@app.on_event("shutdown")
+async def shutdown():
+    await prisma.disconnect()
+
+@app.get("/tenants", response_model=list[Tenant])
+async def list_tenants():
+    return await prisma.tenant.find_many()
+
+@app.post("/tenants", response_model=Tenant)
+async def create_tenant(data: TenantIn):
+    return await prisma.tenant.create({"data": {"name": data.name}})
+
+@app.delete("/tenants/{tenant_id}")
+async def delete_tenant(tenant_id: str):
+    record = await prisma.tenant.delete({"where": {"id": tenant_id}})
+    if not record:
+        raise HTTPException(status_code=404, detail="Not found")
+    return record

--- a/apps/api/requirements.txt
+++ b/apps/api/requirements.txt
@@ -1,0 +1,3 @@
+fastapi
+uvicorn
+prisma-client-py

--- a/apps/web/components/Layout.tsx
+++ b/apps/web/components/Layout.tsx
@@ -1,0 +1,25 @@
+import { ReactNode } from 'react';
+import Link from 'next/link';
+import { UserButton, SignedIn, SignedOut, SignInButton } from '@clerk/nextjs';
+import { TenantSwitcher } from './TenantSwitcher';
+
+export default function Layout({ children }: { children: ReactNode }) {
+  return (
+    <div className="min-h-screen flex flex-col">
+      <header className="p-4 bg-gray-100 flex justify-between items-center">
+        <h1 className="font-bold">ScoutAI</h1>
+        <div className="flex items-center gap-4">
+          <TenantSwitcher />
+          <SignedIn>
+            <UserButton />
+          </SignedIn>
+          <SignedOut>
+            <SignInButton />
+          </SignedOut>
+        </div>
+      </header>
+      <main className="p-4 flex-grow">{children}</main>
+      <footer className="p-4 text-center text-sm text-gray-500">©2023</footer>
+    </div>
+  );
+}

--- a/apps/web/components/TenantSwitcher.tsx
+++ b/apps/web/components/TenantSwitcher.tsx
@@ -1,0 +1,43 @@
+'use client';
+import { useState, useEffect } from 'react';
+import { useUser } from '@clerk/nextjs';
+import { supabase } from '../lib/supabase';
+import { Input } from '@ui';
+
+export function TenantSwitcher() {
+  const { user } = useUser();
+  const [tenants, setTenants] = useState<{id: string; name: string}[]>([]);
+  const [current, setCurrent] = useState('');
+
+  useEffect(() => {
+    async function loadTenants() {
+      if (user) {
+        const res = await supabase
+          .from('tenants')
+          .select('id, name')
+          .eq('id', user.publicMetadata.tenant_id as string);
+        if (!res.error && res.data) {
+          setTenants(res.data);
+          setCurrent(res.data[0]?.id ?? '');
+        }
+      }
+    }
+    loadTenants();
+  }, [user]);
+
+  if (!user) return null;
+
+  return (
+    <select
+      className="border rounded px-2 py-1"
+      value={current}
+      onChange={(e) => setCurrent(e.target.value)}
+    >
+      {tenants.map((t) => (
+        <option key={t.id} value={t.id}>
+          {t.name}
+        </option>
+      ))}
+    </select>
+  );
+}

--- a/apps/web/pages/admin/_actions.ts
+++ b/apps/web/pages/admin/_actions.ts
@@ -1,13 +1,13 @@
 "use server";
 
-import { checkRole } from "@/../../lib/utils";
+import { checkRole } from "@/utils";
 import { clerkClient } from "@clerk/nextjs/server";
 
 export async function setRole(formData: FormData) {
   const client = await clerkClient();
 
-  // Check that the user trying to set the role is an admin
-  if (!checkRole("admin")) {
+  // Check that the user trying to set the role is a business admin
+  if (!(await checkRole("business"))) {
     console.log("Not Authorized");
     // return { message: "Not Authorized" };
   }
@@ -29,6 +29,11 @@ export async function setRole(formData: FormData) {
 
 export async function removeRole(formData: FormData) {
   const client = await clerkClient();
+
+  if (!(await checkRole("business"))) {
+    console.log("Not Authorized");
+    return;
+  }
 
   try {
     const res = await client.users.updateUserMetadata(

--- a/apps/web/pages/admin/page.tsx
+++ b/apps/web/pages/admin/page.tsx
@@ -1,5 +1,5 @@
 import { redirect } from "next/navigation";
-import { checkRole } from "@/../../lib/utils";
+import { checkRole } from "@/utils";
 import { SearchUsers } from "./components/SearchUsers";
 import { clerkClient } from "@clerk/nextjs/server";
 import { removeRole, setRole } from "./_actions";
@@ -7,7 +7,7 @@ import { removeRole, setRole } from "./_actions";
 export default async function AdminDashboard(params: {
   searchParams: Promise<{ search?: string }>;
 }) {
-  if (!checkRole("admin")) {
+  if (!(await checkRole("business"))) {
     redirect("/");
   }
 

--- a/apps/web/pages/business/_actions.ts
+++ b/apps/web/pages/business/_actions.ts
@@ -1,0 +1,21 @@
+'use server';
+
+export async function createTenant(formData: FormData) {
+  await fetch('/api/super/createTenant', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name: formData.get('name') }),
+  });
+}
+
+export async function createUser(formData: FormData) {
+  await fetch('/api/super/createUser', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      email: formData.get('email'),
+      name: formData.get('name'),
+      tenantId: formData.get('tenantId'),
+    }),
+  });
+}

--- a/apps/web/pages/business/components/CreateTenantForm.tsx
+++ b/apps/web/pages/business/components/CreateTenantForm.tsx
@@ -1,0 +1,23 @@
+'use client';
+import { FormEvent, useState } from 'react';
+import { createTenant } from '../_actions';
+import { Button, Input } from '@ui';
+
+export function CreateTenantForm() {
+  const [name, setName] = useState('');
+
+  async function onSubmit(e: FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    const fd = new FormData();
+    fd.append('name', name);
+    await createTenant(fd);
+    setName('');
+  }
+
+  return (
+    <form onSubmit={onSubmit} className="space-x-2">
+      <Input value={name} onChange={(e) => setName(e.target.value)} placeholder="Tenant name" />
+      <Button type="submit">Create Tenant</Button>
+    </form>
+  );
+}

--- a/apps/web/pages/business/components/CreateUserForm.tsx
+++ b/apps/web/pages/business/components/CreateUserForm.tsx
@@ -1,0 +1,31 @@
+'use client';
+import { FormEvent, useState } from 'react';
+import { createUser } from '../_actions';
+import { Button, Input } from '@ui';
+
+export function CreateUserForm() {
+  const [email, setEmail] = useState('');
+  const [name, setName] = useState('');
+  const [tenantId, setTenantId] = useState('');
+
+  async function onSubmit(e: FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    const fd = new FormData();
+    fd.append('email', email);
+    fd.append('name', name);
+    fd.append('tenantId', tenantId);
+    await createUser(fd);
+    setEmail('');
+    setName('');
+    setTenantId('');
+  }
+
+  return (
+    <form onSubmit={onSubmit} className="space-x-2">
+      <Input value={email} onChange={(e) => setEmail(e.target.value)} placeholder="Email" />
+      <Input value={name} onChange={(e) => setName(e.target.value)} placeholder="Name" />
+      <Input value={tenantId} onChange={(e) => setTenantId(e.target.value)} placeholder="Tenant ID" />
+      <Button type="submit">Add User</Button>
+    </form>
+  );
+}

--- a/apps/web/pages/business/index.tsx
+++ b/apps/web/pages/business/index.tsx
@@ -1,0 +1,21 @@
+import Layout from '../../components/Layout';
+import { checkRole } from '@/utils';
+import { redirect } from 'next/navigation';
+import { CreateTenantForm } from './components/CreateTenantForm';
+import { CreateUserForm } from './components/CreateUserForm';
+
+export default async function BusinessHome() {
+  if (!(await checkRole('business'))) {
+    redirect('/');
+  }
+
+  return (
+    <Layout>
+      <h2 className="text-xl mb-4">Business Dashboard</h2>
+      <div className="space-y-4">
+        <CreateTenantForm />
+        <CreateUserForm />
+      </div>
+    </Layout>
+  );
+}

--- a/apps/web/pages/candidate/_actions.ts
+++ b/apps/web/pages/candidate/_actions.ts
@@ -1,0 +1,5 @@
+'use server';
+
+export async function exampleCandidateAction() {
+  // placeholder
+}

--- a/apps/web/pages/candidate/index.tsx
+++ b/apps/web/pages/candidate/index.tsx
@@ -1,0 +1,15 @@
+import Layout from '../../components/Layout';
+import { checkRole } from '@/utils';
+import { redirect } from 'next/navigation';
+
+export default async function CandidateHome() {
+  if (!(await checkRole('candidate'))) {
+    redirect('/');
+  }
+
+  return (
+    <Layout>
+      <p>Candidate dashboard</p>
+    </Layout>
+  );
+}

--- a/apps/web/pages/index.tsx
+++ b/apps/web/pages/index.tsx
@@ -1,23 +1,22 @@
-import Link from "next/link";
-import { SignedIn, SignedOut, UserButton } from "@clerk/nextjs";
-import { greet } from "@/utils";
+import { useUser, SignIn } from '@clerk/nextjs';
+import { useRouter } from 'next/router';
+import { useEffect } from 'react';
 
 export default function Home() {
-  return (
-    <main>
-      <h1>ScoutAI</h1>
-      <SignedIn>
-        <UserButton />
-        <p>
-          <Link href="/profile">Edit Profile</Link>
-        </p>
-      </SignedIn>
-      <SignedOut>
-        <p>
-          <Link href="/sign-in">Sign In</Link> |{" "}
-          <Link href="/sign-up">Sign Up</Link>
-        </p>
-      </SignedOut>
-    </main>
-  );
+  const { user } = useUser();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (user) {
+      const role = user.publicMetadata.role as string | undefined;
+      if (role) {
+        router.replace(`/${role}`);
+      }
+    }
+  }, [user, router]);
+
+  if (!user) {
+    return <SignIn path="/" routing="path" />;
+  }
+  return null;
 }

--- a/apps/web/pages/recruiter/_actions.ts
+++ b/apps/web/pages/recruiter/_actions.ts
@@ -1,0 +1,5 @@
+'use server';
+
+export async function exampleRecruiterAction() {
+  // placeholder
+}

--- a/apps/web/pages/recruiter/index.tsx
+++ b/apps/web/pages/recruiter/index.tsx
@@ -1,0 +1,15 @@
+import Layout from '../../components/Layout';
+import { checkRole } from '@/utils';
+import { redirect } from 'next/navigation';
+
+export default async function RecruiterHome() {
+  if (!(await checkRole('recruiter'))) {
+    redirect('/');
+  }
+
+  return (
+    <Layout>
+      <p>Recruiter dashboard</p>
+    </Layout>
+  );
+}

--- a/infrastructure/supabase/rls_policies.sql
+++ b/infrastructure/supabase/rls_policies.sql
@@ -13,8 +13,8 @@ ALTER TABLE "companies" ENABLE ROW LEVEL SECURITY;
 CREATE POLICY "users can view their tenant"
 ON "tenants"
 FOR SELECT
-USING ( 
-  auth.jwt() ->> 'tenant_id' = id
+USING (
+  auth.jwt() ->> 'tenant_id' = id AND auth.jwt() ->> 'role' = 'business'
 );
 
 -- 2. users Table

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   ],
   "scripts": {
     "dev:web": "pnpm --filter web dev",
-    "dev:api": "uvicorn api.main:app --reload --host 0.0.0.0 --port 8000",
+    "dev:api": "uvicorn apps.api.main:app --reload --host 0.0.0.0 --port 8000",
     "dev": "concurrently \"pnpm dev:web\" \"pnpm dev:api\"",
     "generate": "prisma generate --schema=packages/prisma/schema.prisma",
     "build": "turbo run build"

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -19,6 +19,7 @@ enum CandidateStatus {
   HIRED
   REJECTED
   @@schema("api")
+  @@map("candidate_status")
 }
 
 enum CandidateCareerLevel {
@@ -28,7 +29,7 @@ enum CandidateCareerLevel {
   DIRECTOR_LEVEL
   C_LEVEL
   @@schema("api")
-
+  @@map("candidate_career_level")
 }
 
 enum CandidateInterest {
@@ -36,6 +37,7 @@ enum CandidateInterest {
   NOT_INTERESTED
   OPEN_TO_WORK
   @@schema("api")
+  @@map("candidate_interest")
 }
 
 enum CompanyStage {
@@ -48,6 +50,7 @@ enum CompanyStage {
   PUBLIC
   PRIVATE
   @@schema("api")
+  @@map("company_stage")
 }
 
 enum JobStatus {
@@ -56,6 +59,7 @@ enum JobStatus {
   ON_HOLD
   FILLED
   @@schema("api")
+  @@map("job_status")
 }
 
 enum CompanySize {
@@ -68,6 +72,7 @@ enum CompanySize {
   SIZE_1000_5000
   SIZE_5000_PLUS
   @@schema("api")
+  @@map("company_size")
 }
 
 enum Industry {
@@ -89,6 +94,7 @@ enum Industry {
   AGRICULTURE
   OTHER
   @@schema("api")
+  @@map("industry")
 }
 
 model Tenant {

--- a/packages/ui/button.tsx
+++ b/packages/ui/button.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {}
+
+export const Button: React.FC<ButtonProps> = ({ children, className='', ...props }) => (
+  <button className={`px-4 py-2 bg-blue-500 text-white rounded ${className}`} {...props}>
+    {children}
+  </button>
+);

--- a/packages/ui/index.ts
+++ b/packages/ui/index.ts
@@ -1,0 +1,2 @@
+export { Button } from './button';
+export { Input } from './input';

--- a/packages/ui/input.tsx
+++ b/packages/ui/input.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {}
+
+export const Input: React.FC<InputProps> = ({ className='', ...props }) => (
+  <input className={`border px-2 py-1 rounded ${className}`} {...props} />
+);

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "ui",
+  "version": "0.0.1",
+  "main": "index.ts",
+  "dependencies": {}
+}


### PR DESCRIPTION
## Summary
- implement FastAPI skeleton for Prisma usage
- restrict `/admin` access to business role
- map Prisma enums to snake case
- redirect index page based on role
- add role-based experiences and shared layout
- add small UI component library
- update Supabase policy for role check

## Testing
- `npm run build` *(fails: turbo not found)*