### PR TITLE
Add Python virtual environment setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,15 @@ Tailwind and PostCSS configuration files are written in TypeScript.
 
 ## Installation
 
-To install all Node and Python dependencies, run:
+Run the install script to set up Node dependencies and create the Python
+virtual environment:
 
 ```bash
 ./scripts/install.sh
+```
+
+After installation, activate the environment when working on the API:
+
+```bash
+source scripts/activate_venv.sh
 ```

--- a/scripts/activate_venv.sh
+++ b/scripts/activate_venv.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# Activate the Python virtual environment for the API
+source "$(dirname "$0")/../apps/api/.venv/bin/activate"
+

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -4,5 +4,11 @@ set -e
 # Install Node dependencies
 pnpm install
 
+# Set up Python virtual environment
+bash "$(dirname "$0")/setup_venv.sh"
+source apps/api/.venv/bin/activate
+
 # Install Python dependencies for API
 pip install -r apps/api/requirements.txt
+
+echo "Python virtual environment ready at apps/api/.venv"

--- a/scripts/setup_venv.sh
+++ b/scripts/setup_venv.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -e
+
+# Create Python virtual environment for the API if it does not exist
+if [ ! -d "apps/api/.venv" ]; then
+  python3 -m venv apps/api/.venv
+  echo "Created Python virtual environment at apps/api/.venv" 
+fi
+


### PR DESCRIPTION
## Summary
- create helper scripts for managing a Python virtual environment
- update install script to create and use the venv
- document the new workflow in the README

## Testing
- `bash scripts/setup_venv.sh`
- `bash scripts/install.sh` *(fails: GET https://registry.npmjs.org/... EHOSTUNREACH)*