### PR TITLE
Fix Next.js server action build error

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -1,7 +1,9 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  experimental: {
+    serverActions: true,
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary
- enable server actions in the web `next.config.ts`

## Testing
- `pnpm --filter web build` *(fails: `next: not found`)*